### PR TITLE
add: summary, operationId, tags field

### DIFF
--- a/src/lib/builder.js
+++ b/src/lib/builder.js
@@ -611,6 +611,10 @@ function createPostmanImport(apiSpecList, stage) {
             const api = obj[property][method];
             paths[_property][method] = {};
             paths[_property][method].description = api.desc;
+            paths[_property][method].summary = api.summary;
+            paths[_property][method].operationId = api.operationId;
+            paths[_property][method].tags = [api.category, ...(api.tags || [])];
+
             if (!api.noAuth) {
                 paths[_property][method].security =
                     [{


### PR DESCRIPTION
api spec 에서 사용할 수 있는 필드를 추가합니다.

- summary : 한줄설명 (OAS 문서화시 타이틀로 주로 사용됨)
- operationId : 커스텀 식별자 (API 식별용 고유 커스텀 ID )
- tags : API 그룹핑 (기존 apiSpec 에 카테고리와 비슷)

![image](https://github.com/spark323/slsberry/assets/150875944/e719a42d-3411-4c5a-9e13-858a1a4b1c74)
