### PR TITLE
feat: using docs/components dir, generate components

### DIFF
--- a/__tests__/builder.test.js
+++ b/__tests__/builder.test.js
@@ -1,4 +1,4 @@
-const { generateOasPaths } = require('../src/lib/builder');
+const { generateOasPaths, generateOasComponents } = require('../src/lib/builder');
 
 describe('builder', () => {
   
@@ -354,6 +354,42 @@ describe('builder', () => {
           }
         }
       });
+
+    });
+
+  });
+
+  describe('generateOasComponents', () => {
+
+    test('if there is no target dir, return empty object', async () => {
+
+      const result = await generateOasComponents('__tests__/no_dir');
+
+      expect(result).toEqual({});
+
+    });
+
+    test('should generate components properly', async () => {
+
+      const components = await generateOasComponents('__tests__/docs/components');
+      
+      expect(components).toHaveProperty('schemas');
+      expect(components).toHaveProperty('parameters');
+      expect(components).toHaveProperty('schemas');
+
+      expect(components.schemas).not.toHaveProperty('somename'); // file name이 아니라, schema name이다.
+      expect(components.schemas).toHaveProperty('Todo');
+      expect(components.schemas).toHaveProperty('User');
+
+      expect(components.parameters).toHaveProperty('limit');
+      expect(components.parameters).toHaveProperty('page');
+
+      expect(components.responses).toHaveProperty('NotFound');
+      expect(components.responses).toHaveProperty('Unauthorized');
+
+      expect(components.examples).toHaveProperty('todo');
+      expect(components.examples).toHaveProperty('user');
+
 
     });
 

--- a/__tests__/docs/components/examples/todo.yaml
+++ b/__tests__/docs/components/examples/todo.yaml
@@ -1,0 +1,8 @@
+todo:
+  value:
+    id: 0
+    name: string
+    completed: true
+    completed_at: '2019-08-24T14:15:22Z'
+    created_at: '2019-08-24T14:15:22Z'
+    updated_at: '2019-08-24T14:15:22Z'

--- a/__tests__/docs/components/examples/user.yaml
+++ b/__tests__/docs/components/examples/user.yaml
@@ -1,0 +1,7 @@
+user:
+  value:
+    userId: 2
+    firstName: racks
+    lastName: jacson
+    phoneNumber: '123456'
+    emailAddress: racks.jacson@learningcontainer.com

--- a/__tests__/docs/components/parameters/limit.yaml
+++ b/__tests__/docs/components/parameters/limit.yaml
@@ -1,0 +1,7 @@
+limit:
+  name: limit
+  in: query
+  required: false
+  schema:
+    type: number
+  description: Return a limited set of results *I'm a shared parameter. I can be reused in multiple endpoints!*

--- a/__tests__/docs/components/parameters/page.yaml
+++ b/__tests__/docs/components/parameters/page.yaml
@@ -1,0 +1,7 @@
+page:
+  name: page
+  in: query
+  required: false
+  schema:
+    type: number
+  description: Return the page number

--- a/__tests__/docs/components/responses/NotFound.yaml
+++ b/__tests__/docs/components/responses/NotFound.yaml
@@ -1,0 +1,19 @@
+NotFound:
+  description: Resource not found
+  content:
+    application/json:
+      schema:
+        title: Error
+        type: object
+        description: A standard error object.
+        x-tags:
+          - Common
+        properties:
+          status:
+            type: string
+            description: A code.
+          error:
+            type: string
+        required:
+          - status
+          - error

--- a/__tests__/docs/components/responses/Unauthorized.yaml
+++ b/__tests__/docs/components/responses/Unauthorized.yaml
@@ -1,0 +1,11 @@
+Unauthorized:
+    description: Action not allowed
+    content:
+      application/json:
+        schema:
+          type: object
+          properties:
+            message:
+              type: string
+          required:
+            - message

--- a/__tests__/docs/components/schemas/User.yaml
+++ b/__tests__/docs/components/schemas/User.yaml
@@ -1,0 +1,31 @@
+User:
+  description: ''
+  type: object
+  title: User
+  properties:
+    userId:
+      type: number
+      description: ID of the user
+      readOnly: true
+    firstName:
+      type: string
+      minLength: 1
+      description: ''
+    lastName:
+      type: string
+      minLength: 1
+      description: ''
+    phoneNumber:
+      type: string
+      minLength: 1
+      description: Official Phone Number
+    emailAddress:
+      type: string
+      minLength: 1
+      description: Work Email Address
+  required:
+    - userId
+    - firstName
+    - lastName
+    - phoneNumber
+    - emailAddress

--- a/__tests__/docs/components/schemas/somename.yaml
+++ b/__tests__/docs/components/schemas/somename.yaml
@@ -1,0 +1,41 @@
+Todo:
+  description: I'm a model's description.
+  type: object
+  title: Todo
+  properties:
+    id:
+      type: number
+      minimum: 0
+      maximum: 9999
+      description: ID of the task
+      readOnly: true
+    name:
+      type: string
+      minLength: 1
+      maxLength: 100
+      description: Name of the task
+    completed:
+      type: boolean
+      default: false
+      description: Boolean indicating if the task has been completed or not
+    completed_at:
+      type: string
+      format: date-time
+      description: Time when the task was completed
+      readOnly: true
+    created_at:
+      type: string
+      format: date-time
+      description: Time when the task was created
+      readOnly: true
+    updated_at:
+      type: string
+      format: date-time
+      description: Time when the task was updated
+      readOnly: true
+  required:
+    - id
+    - name
+    - completed_at
+    - created_at
+    - updated_at


### PR DESCRIPTION
### 작업설명
- OAS 에서 공통으로 사용할 수 있는 components 들을 api docs 에 추가할 수 있도록 하였습니다.
1. 루트 경로에 다음과 같이 디렉토리 및 파일들을 추가하면
![image](https://github.com/spark323/slsberry/assets/150875944/4550188f-09f3-4a5c-985d-d12917cc919b)
2. api 문서가 generate 될 때, 해당 경로를 참조하여 [components section](https://swagger.io/docs/specification/components/) 에 내용을 채워넣습니다.
![image](https://github.com/spark323/slsberry/assets/150875944/a7f388ed-0882-4e11-8bdd-5d56a71b818c)
