### PR TITLE
add: use operaionId as a function name

### DIFF
--- a/src/lib/builder.js
+++ b/src/lib/builder.js
@@ -906,7 +906,7 @@ async function printServerlessFunction(templateFile, apiSpecList, stage, version
                 if (item && (item.disabled !== true) && (!(item.disabled_stages && item.disabled_stages.includes(stage)))) {
                     const nameArr = item.name.split("/");
                     let funcObject = {
-                        name: item.functionName ? item.functionName : (`\${self:service}_${stage}_${version}_${nameArr.join("_")}`),
+                        name: item.functionName ? item.functionName : (`\${self:service}_${stage}_${version}_${(item.operationId).replace(/\./g, "_").replace(/[{}]/g, "_")}`),
                         handler: `src/lambda/${item.name}.handler`,
                         events: [],
                     };
@@ -1165,7 +1165,7 @@ async function printServerlessFunction(templateFile, apiSpecList, stage, version
                     if (item.ephemeralStorageSize) {
                         funcObject["ephemeralStorageSize"] = parseInt(item.ephemeralStorageSize);
                     }
-                    functions[`${nameArr.join("_")}`] = funcObject;
+                    functions[(item.operationId).replace(/\./g, "_")] = funcObject;
                 }
             });
         }


### PR DESCRIPTION
- apiSpec.operationId 가 있다면,  serverless function name 으로 사용합니다. (path 기반으로 자동 생성되는 name 보다 우선하여)
- 반드시, operationId 는 API 를 구분하는 고유한 식별자로써 사용하도록 합니다.