### PR TITLE
feat: if operation is undefined, auto generate it

### DIFF
--- a/src/lib/apispec/index.js
+++ b/src/lib/apispec/index.js
@@ -73,7 +73,6 @@ async function getApiSpecList(targetFiles) {
 
       if (obj) {
         // Add additional properties to the API specification object
-        obj.operationId = obj.operationId || name;
         obj.name = name;
         obj.uri = replaceHttpMethod(name);
 
@@ -453,16 +452,18 @@ function generateOasPaths(apiSpecList) {
         return;
       }
 
-      const path = item.event.find(
-        (e) => e.type.toLowerCase() === "rest"
-      )?.path;
-      const uri = path ? path : item.uri;
+      item.event.forEach((e) => {
+        if (e.type.toLowerCase() === "rest") {
+          const path = e.path;
+          const uri = path ? path : item.uri;
 
-      if (!sortedApiSpecList[uri]) {
-        sortedApiSpecList[uri] = [];
-      }
+          if (!sortedApiSpecList[uri]) {
+            sortedApiSpecList[uri] = [];
+          }
 
-      sortedApiSpecList[uri][item.event[0].method.toLowerCase()] = item;
+          sortedApiSpecList[uri][e.method.toLowerCase()] = item;
+        }
+      });
     });
   }
 
@@ -481,7 +482,8 @@ function generateOasPaths(apiSpecList) {
       paths[_property][method] = {};
       paths[_property][method].description = api.desc;
       paths[_property][method].summary = api.summary;
-      paths[_property][method].operationId = api.operationId;
+      paths[_property][method].operationId =
+        api.operationId || method.toUpperCase() + " " + _property;
       paths[_property][method].tags = [api.category, ...(api.tags || [])];
 
       if (!api.noAuth) {

--- a/src/lib/apispec/index.js
+++ b/src/lib/apispec/index.js
@@ -143,7 +143,7 @@ async function printServerlessFunction(
                   method: `${item.method
                       ? item.method.toLowerCase()
                       : item.event.method.toLowerCase()
-                    }`,
+                  }`,
                   authorizer: item.authorizer
                     ? { name: item.authorizer }
                     : undefined,
@@ -653,8 +653,15 @@ function generateOasPaths(apiSpecList) {
         paths[_property][method].requestBody = api.requestBody;
       }
 
-      if (api.requestQuery) {
-        paths[_property][method].parameters = api.requestQuery;
+      if (api.requestQuery || api.requestPath) {
+        const requestQuery = api.requestQuery || [];
+        const requestPath = api.requestPath || [];
+
+        paths[_property][method].parameters = [
+          // ...paths[_property][method].parameters,
+          ...requestQuery,
+          ...requestPath,
+        ];
       }
 
       if (api.responses && !api.responses.content) {


### PR DESCRIPTION
- operationId 는 method + path 를 기본값으로 사용하도록 수정
- apispec 내 rest event 가 다수일 경우에도 모두 문서화 할 수 있도록 수정
- apispec 내 requestPath 가 있을 경우, parameters 에 값을 추가하도록 수정